### PR TITLE
Auto-fill time range

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ var output = SVGTimeGraph(
         // Points that are not in the interval will be ignored
         autoFillInterval: 1000 * 60 * 60 * 24,
 
+        // By default, autoFill completes the serie from the minimum date
+        // to the maximum date of the series
+        // Override this behavior by setting the two following options
+
+        // Default to minimum date of the series
+        autoFillStartTime: new Date(2015, 06, 07),
+        // Default to maximum date of the series
+        autoFillEndTime: new Date(2015, 06, 14)
+
         // Other options...
     }
 );

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,6 +92,9 @@ Graph.prototype.bindSeries = function(series) {
         that.dateMin = that.opts.autoFillStartTime || that.dateMin;
         that.dateMax = that.opts.autoFillEndTime || that.dateMax;
 
+        // Set endTime to construct serie
+        var serieEndTime = that.opts.autoFillEndTime? that.dateMax : that.dateMax + that.opts.autoFillInterval;
+
         // Set valueMin and valueMax
         that.valueMin = Math.min(that.valueMin, that.opts.autoFillValue);
         that.valueMax = Math.max(that.valueMax, that.opts.autoFillValue);
@@ -103,7 +106,7 @@ Graph.prototype.bindSeries = function(series) {
             var serieLength = serie.points.length;
 
             // Fill current serie with existing points or with autoFillValue
-            serie.points = _.map(_.range(that.dateMin, that.dateMax, that.opts.autoFillInterval), function(time) {
+            serie.points = _.map(_.range(that.dateMin, serieEndTime, that.opts.autoFillInterval), function(time) {
                 var data = null;
 
                 if (serieI < serieLength) data = serie.points[serieI];

--- a/lib/index.js
+++ b/lib/index.js
@@ -313,9 +313,9 @@ Graph.prototype.drawSerie = function(serie, serieI) {
             // Draw vertical axe
             that.svg.line({
                 'x1': pos.x,
-                'y1': that.innerY + that.innerHeight,
+                'y1': that.innerY,
                 'x2': pos.x,
-                'y2': that.opts.padding,
+                'y2': that.innerY + that.innerHeight,
                 'stroke': that.opts.axeColor,
                 'stroke-width': that.opts.lineWidth
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,13 @@ var Graph = function(series, opts) {
 
         // Points minimum
         minValue: null,
+
+        // Auto-fill options
         autoFill: false,
         autoFillValue: 0,
         autoFillInterval: null,
+        autoFillStartTime: null,
+        autoFillEndTime: null,
 
         // Styling
         padding: 10,
@@ -77,6 +81,17 @@ Graph.prototype.bindSeries = function(series) {
     if (that.opts.autoFill) {
         if (!that.opts.autoFillInterval) throw 'Need an interval to use autoFill';
 
+        // Set autoFill times to timestamps if provided
+        if (that.opts.autoFillStartTime) {
+            that.opts.autoFillStartTime = new Date(that.opts.autoFillStartTime).getTime();
+        }
+        if (that.opts.autoFillEndTime) {
+            that.opts.autoFillEndTime = new Date(that.opts.autoFillEndTime).getTime();
+        }
+        // Set start and end time depending on options
+        that.dateMin = that.opts.autoFillStartTime || that.dateMin;
+        that.dateMax = that.opts.autoFillEndTime || that.dateMax;
+
         // Set valueMin and valueMax
         that.valueMin = Math.min(that.valueMin, that.opts.autoFillValue);
         that.valueMax = Math.max(that.valueMax, that.opts.autoFillValue);
@@ -88,7 +103,7 @@ Graph.prototype.bindSeries = function(series) {
             var serieLength = serie.points.length;
 
             // Fill current serie with existing points or with autoFillValue
-            serie.points = _.map(_.range(that.dateMin, that.dateMax + that.opts.autoFillInterval, that.opts.autoFillInterval), function(time) {
+            serie.points = _.map(_.range(that.dateMin, that.dateMax, that.opts.autoFillInterval), function(time) {
                 var data = null;
 
                 if (serieI < serieLength) data = serie.points[serieI];

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ Graph.prototype.bindSeries = function(series) {
     this.hPerValue = this.opts.height/(this.valueMax - this.valueMin);
 
     // Calcul axes sizes
-    this.axeYWidth = this.valueMax.toFixed(0).length * this.opts.textFontSize * 1.5;
+    this.axeYWidth = this.valueMax.toFixed(0).length * this.opts.textFontSize * 1.5 + that.opts.axeMarkerWidth;
     this.axeYInterval = ((this.valueMax - this.valueMin) * this.hPerValue) / (this.opts.textFontSize * 4);
 
     this.axeXHeight = this.opts.textFontSize * 3;


### PR DESCRIPTION
Add `autoFillStartTime` and `autoFillEndTime` properties to get a time serie over a defined period.
Also fixes display issues.
